### PR TITLE
Add (and fix) generated docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+concurrency:
+  cancel-in-progress: false
+  group: pages
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+    - uses: cachix/install-nix-action@v23
+      with:
+        extra_nix_config: |
+          extra-trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
+          extra-substituters = https://cache.garnix.io
+    - uses: lriesebos/nix-develop-command@v1
+      with:
+        command: |
+          cabal haddock-project \
+            --haddock-option='--base-url=.' \
+            --haddock-option='--use-contents=../index.html' \
+            --haddock-option='--use-index=../doc-index.html' \
+            --local \
+            --output=_site
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+  deploy:
+    environment:
+      name: github-pages
+      url: "${{ steps.deployment.outputs.page_url }}"
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - id: deployment
+      name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v4
+name: Deploy generated docs to Pages
+'on':
+  push:
+    branches:
+    - master
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  pages: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.*
 !.travis*
 *.stackwork
 *out/

--- a/inline/src/ConCat/Inline/SampleMethods.hs
+++ b/inline/src/ConCat/Inline/SampleMethods.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 -- {-# OPTIONS_GHC -Wno-unused-imports #-} -- TEMP
 
@@ -10,7 +11,10 @@
 -- {-# OPTIONS_GHC -ddump-rule-rewrites #-}
 -- {-# OPTIONS_GHC -ddump-rules #-}
 
+-- Haddock throws an exception if this plugin is enabled here.
+#ifdef D__HADDOCK_VERSION__
 {-# OPTIONS_GHC -fplugin=ConCat.Inline.Plugin #-}
+#endif
 
 module ConCat.Inline.SampleMethods where
 


### PR DESCRIPTION
Noticed when generating Haddock for a downstream project that concat’s Haddock was broken. This fixes it and generates Haddock into GitHub Pages, which also helps ensure the Haddock will keep working.