### PR TITLE
Fix permissions on Haddock before deploying

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,9 @@ jobs:
             --haddock-option='--use-index=../doc-index.html' \
             --local \
             --output=_site
+          ## Fix permissions to match the action’s expectations (see
+          ## https://github.com/actions/upload-pages-artifact#file-permissions)
+          chmod -c -R +rX "_site/"
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
   deploy:


### PR DESCRIPTION
It’s difficult to test branch-specific GitHub workflows like this, so the final
deployment bits couldn’t be tested before merging the previous PR.

In this case, I merged the change into `master` on my fork to ensure it actually completed. So you can see the result at https://con-kitty.github.io/concat/.